### PR TITLE
docs: add standalone workspaces guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ look up later":
 | [`code-reviewer.md`](code-reviewer.md) | How to use Memtrace as a GitHub PR reviewer from the CLI or an agent: feature branch, PR, posted review, watched commands, and optional local fixes. |
 | [`cli-reference.md`](cli-reference.md) | Current `memtrace --help` command surface: start/status/index/MCP, code review, PR watches, embedding provider commands, flags, and key env vars. |
 | [`architecture.md`](architecture.md) | High-level picture of the components — daemon, MCP server, MemDB, indexer, embedding pipeline. No deep internals; just enough to reason about behaviour. |
+| [`workspaces.md`](workspaces.md) | Share one knowledge graph across multiple repos: when to use a workspace, the `.memtrace-workspace` marker, resolution order, cross-repo edges, and the `--workspace` flag. |
 | [`data-directories.md`](data-directories.md) | Every directory Memtrace creates: `.memdb/`, `.memtrace/`, `~/.memtrace/embed-cache/`, model caches. What's in each, where it lives, when to delete it. |
 | [`embedding-providers.md`](embedding-providers.md) | Local presets, remote/BYO embedding providers (OpenAI, Voyage, Ollama, Infinity, TEI, …), Matryoshka dim truncation, the `memtrace embed` CLI. |
 | [`environment-variables.md`](environment-variables.md) | The full env var reference — transport, ports, model selection, RAM tuning, embedding caps. |

--- a/docs/data-directories.md
+++ b/docs/data-directories.md
@@ -54,6 +54,10 @@ The MemDB graph engine's on-disk store. Created the first time you run
    marker is found, Memtrace uses the nearest git repo root.
 3. **Current working directory** if neither marker nor git root is found.
 
+For the full story on multi-repo setups — why to use a workspace,
+cross-repo edges, and the `--workspace` flag — see
+[`workspaces.md`](workspaces.md). This page covers the storage side.
+
 Quick way to confirm where YOUR `.memdb` is on a running system:
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,6 +146,11 @@ That gives the machine a background workspace owner. Later
 `memtrace mcp` processes attach to it instead of opening another
 embedded MemDB.
 
+Working across several related repos (frontend + backend, a monorepo,
+a service mesh)? Index them under one **workspace** so they share a
+single graph and cross-repo questions resolve — see
+[`workspaces.md`](workspaces.md).
+
 ## Tell your agent to use Memtrace
 
 If you installed via npm, the integrations for the major AI tools are

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -243,6 +243,10 @@ Encore, Flask, …) and the call sites that hit them, including from
 *other indexed repos*. The diagram is Mermaid-ready — paste it into
 your docs.
 
+For this to work the repos must share one knowledge graph — index
+them under a single **workspace**. See [`workspaces.md`](workspaces.md)
+for the `.memtrace-workspace` marker and the `--workspace` flag.
+
 ## "How am I doing on token cost?"
 
 Memtrace estimates how many tokens it saved you by answering

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,0 +1,197 @@
+# Workspaces
+
+A **workspace** lets several repositories share **one** Memtrace
+knowledge graph, so the agent can answer questions *across* repo
+boundaries — your TypeScript frontend's `fetch("/api/users")` links to
+your Rust backend's `Router::route(...)` even though they live in
+separate directories.
+
+If you only ever work in a single repo, you can skip this page —
+Memtrace already does the right thing (one `.memdb/` at your git root).
+Workspaces matter the moment you have **two or more related repos**
+(frontend + backend, a service mesh, a monorepo of packages) and you
+want the graph to see them as one system.
+
+## Why use one
+
+Without a workspace, each repo gets its own isolated `.memdb/`. The
+graphs can't see each other, so cross-repo questions come back empty:
+
+- "What backend endpoint does this client call hit?"
+- "If I rename this route, which frontends break?"
+- "Show the call path from the UI button to the database write."
+
+Put those repos under one workspace and all of that resolves through a
+single graph. Concretely, a workspace gives you:
+
+- **One `.memdb/` store** for every repo beneath it.
+- **Cross-repo edges** — HTTP calls, shared types, imports across
+  service boundaries — detected automatically at index time.
+- **One owner/daemon** for the whole set instead of one per repo.
+
+## Create a workspace
+
+Pick whichever fits how you work. All three end up at the same place: a
+`.memtrace-workspace` marker file at the folder that contains your
+repos.
+
+### Option A — drop a marker (most explicit)
+
+```bash
+cd /path/to/parent-folder    # the folder that holds your repos
+touch .memtrace-workspace    # empty file is fine
+```
+
+### Option B — let the CLI write it
+
+```bash
+memtrace start --workspace .
+# or
+memtrace index --workspace .
+```
+
+`--workspace <path>` treats `path` as the workspace root and writes the
+marker there for you.
+
+### Option C — auto-detect
+
+Run `memtrace start` from a folder that **isn't itself a git repo** but
+contains **2+ child directories that each have their own `.git`**.
+Memtrace recognises the multi-repo shape and writes the marker
+automatically. Opt out with `memtrace start --no-workspace`.
+
+## How Memtrace picks the workspace
+
+When `memtrace start`, `memtrace index`, or `memtrace mcp` boots, it
+walks **up** from the current directory and uses the first of these it
+finds:
+
+1. **`.memtrace-workspace` marker** — explicit anchor. First match
+   wins; every sibling directory beneath it shares one `.memdb/`.
+   *Recommended for monorepos and multi-repo setups.*
+2. **`.git/` root** — per-repo fallback when no marker exists.
+3. **Current working directory** — if neither marker nor git root is
+   found.
+
+Confirm where you actually landed:
+
+```bash
+memtrace status
+```
+
+The startup banner also prints the resolved path:
+
+```
+◆  MemDB embedded — in-process (data dir: /your/path/.memdb)
+```
+
+## Worked example
+
+```
+$ pwd
+/home/me/work/
+
+$ tree -L 1 -a
+.
+├── .memtrace-workspace      ← marker, you touch-ed this
+├── .memdb/                  ← ONE store for all 3 repos
+├── frontend/                ← repo A (git)
+├── backend/                 ← repo B (git)
+└── infra/                   ← repo C (terraform-only, no git)
+
+$ cd frontend && memtrace index .
+# → registers frontend's symbols in /home/me/work/.memdb under repo_id=frontend
+
+$ cd ../backend && memtrace index .
+# → registers backend's symbols in the SAME .memdb under repo_id=backend
+# Cross-language edges between frontend & backend now resolve out of the box.
+```
+
+Without the marker, `frontend/` and `backend/` would each get their own
+`<repo>/.memdb/` and could not see each other.
+
+## What is scoped to a workspace (and what isn't)
+
+| Lives in the workspace | Lives in `~/.memtrace/` (cross-workspace) |
+|---|---|
+| `.memdb/` — graph + vectors for every repo under the anchor | Downloaded embedding & reranker models |
+| `.memtrace/` — indexer job state (transient, small) | `embed-cache/` — per-symbol embedding cache |
+| Workspace-local embedding override (see below) | Session token, global config, logs, watches |
+
+Rule of thumb: **graph data is per-workspace; models, caches, and your
+login are machine-global.** Full directory-by-directory breakdown is in
+[`data-directories.md`](data-directories.md).
+
+## Workspace-local configuration
+
+By default the embedding provider is read from `~/.memtrace/config.toml`
+(machine-global). To pin a different embedder to one workspace only:
+
+```bash
+memtrace embed set jina-code --workspace
+# writes <workspace>/.memtrace/embed.toml
+```
+
+Resolution precedence (highest first):
+
+1. `<workspace>/.memtrace/embed.toml` — workspace-local override
+2. `~/.memtrace/config.toml` — machine-global default
+3. `MEMTRACE_EMBED_MODEL` / `MEMTRACE_VECTOR_DIMS` env vars
+4. Built-in default (`jina-embeddings-v2-base-code`, 768 dims)
+
+See [`embedding-providers.md`](embedding-providers.md) for the provider
+catalogue.
+
+## Switching, listing, and ownership
+
+There is **no `switch` or `list-workspaces` command** — a workspace is
+just a directory. To move between workspaces, run Memtrace from that
+tree; resolution (above) does the rest.
+
+```bash
+memtrace status                          # the active workspace's .memdb path
+find ~ -name .memdb -type d 2>/dev/null   # every store on this machine
+```
+
+Each workspace's `.memdb/` keeps an **owner lock** (`daemon.pid`), so
+`memtrace start`, `memtrace mcp`, and the headless daemon agree on a
+single owner. Extra `memtrace mcp` processes attach to the existing
+owner's loopback endpoint instead of opening a duplicate store. See
+[`mcp-and-transports.md`](mcp-and-transports.md) for the multi-agent
+picture.
+
+## Relevant flags and env vars
+
+| Flag / var | Applies to | Effect |
+|---|---|---|
+| `--workspace <path>` | `start`, `index`, `mcp` | Anchor the workspace at `path`; write the `.memtrace-workspace` marker. |
+| `--no-workspace` | `start` | Skip multi-repo auto-detection; use git root or CWD only. |
+| `MEMTRACE_WORKSPACE_ROOT=<path>` | env | Force the workspace anchor — useful for MCP hosts that launch Memtrace from an unexpected CWD. |
+| `MEMTRACE_MEMDB_DATA_DIR=<path>` | env | Override the `.memdb/` location directly (e.g. a faster disk). |
+
+Full references: [`cli-reference.md`](cli-reference.md) and
+[`environment-variables.md`](environment-variables.md).
+
+## When *not* to use a workspace
+
+- **A single repo** — the git-root fallback already gives you one clean
+  `.memdb/`. No marker needed.
+- **Unrelated projects** — keep them in separate workspaces so their
+  graphs (and impact analysis) stay isolated.
+- **A monorepo where you only want part of it indexed** — use a
+  [`.memtraceignore`](indexing-and-ignore-rules.md) instead of widening
+  the workspace.
+
+## Deleting / resetting
+
+A workspace is its directories — nothing precious lives there that the
+graph can't rebuild.
+
+```bash
+memtrace reset <repo_id>     # remove just one repo's records from the shared graph
+rm -rf .memdb/               # wipe the whole workspace graph (daemon stopped)
+rm .memtrace-workspace       # demote back to per-repo stores
+```
+
+The next `memtrace start` / `memtrace index` re-indexes from scratch.
+Your source code is never touched.


### PR DESCRIPTION
Add docs/workspaces.md explaining the multi-repo workspace concept concept-first: why to use one (cross-repo edges), the three ways to create one, resolution order, a worked example, scoping, workspace- local config, and the --workspace flag/env vars.

Cross-link it from the docs index, data-directories.md (storage angle), workflows.md (cross-service tracing), and getting-started.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/syncable-dev/codesmith/memtrace-public/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783089859&installation_id=130072409&pr_number=6&repository=syncable-dev%2Fmemtrace-public&return_to=https%3A%2F%2Fgithub.com%2Fsyncable-dev%2Fmemtrace-public%2Fpull%2F6&signature=e15f34fae0a7ef8c7f1fb5488aeed82b0f899448a156ef7c74c36519cb42bb44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->