### PR TITLE
docs: explain Cortex MCP setup and recovery

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ look up later":
 | [`environment-variables.md`](environment-variables.md) | The full env var reference — transport, ports, model selection, RAM tuning, embedding caps. |
 | [`mcp-and-transports.md`](mcp-and-transports.md) | How agents talk to Memtrace. stdio (per-session subprocess) vs streamable-HTTP (one server, many concurrent agents). When to pick which. |
 | [`tools.md`](tools.md) | The full MCP tool catalogue — `find_symbol`, `find_code`, `get_symbol_context`, `get_impact`, `get_evolution`, etc. Inputs, outputs, when to use which. |
+| [`cortex.md`](cortex.md) | Cortex decision memory: supported MCP setup, `recall_decision`, governance confirmation, status checks, and recovery without deleting the store. |
 | [`workflows.md`](workflows.md) | Common patterns: starting a new project, onboarding to an unfamiliar codebase, debugging an incident, refactoring safely, time-travel queries. |
 | [`performance-tuning.md`](performance-tuning.md) | Fitting Memtrace to your machine. Auto-tuning by RAM, model selection, batch sizes, RSS guardrails. |
 | [`troubleshooting.md`](troubleshooting.md) | Concrete fixes for the most common failure modes — slow startup, swap blowouts, MCP not appearing in your client, indexing hangs. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -23,7 +23,7 @@ memtrace --help
 | `memtrace doctor [--fix] [--repair-install] [--purge-legacy]` | Diagnose runtime, stale locks, process conflicts, agent skills, and MCP registration. With flags, clean stale runtime state and reinstall local skills/MCP config. |
 | `memtrace mcp` | Run the MCP server for Claude, Cursor, Codex, and other MCP-compatible agents. It attaches to an existing workspace owner or becomes the owner if none is running. |
 | `memtrace index <path>` | Index a repository or workspace into MemDB, then exit. |
-| `memtrace govern <path|glob> [--accept-all]` | Classify governance candidates for review. With `--accept-all`, persist the classifier's include/exclude recommendation for every candidate in the current run. |
+| `memtrace govern <path|glob> [--accept-all]` | Classify governance candidates for review. With `--accept-all`, persist the classifier's recommendation for each governance candidate shown in the preview; `NotGovernance` rows are omitted. |
 | `memtrace govern add|edit <path> ...` | Manually assert or replace one governance document in Cortex decision memory. |
 | `memtrace code-review setup` | Choose the default headless agent for `@memtrace fix this`. |
 | `memtrace code-review --pr <url>` | Review a GitHub pull request using local Memtrace context. |
@@ -67,9 +67,9 @@ See [`cortex.md`](cortex.md).
 
 ## Governance intake
 
-The sweep command classifies files for review. It does not persist a
-preview unless you confirm candidates in the Cortex Governance view or
-pass `--accept-all`:
+The sweep command classifies matched files and shows the governance candidates
+it recognizes. It does not persist a preview unless you confirm candidates in
+the Cortex Governance view or pass `--accept-all`:
 
 ```bash
 memtrace start
@@ -77,9 +77,11 @@ memtrace govern docs/adr
 memtrace govern docs/adr --accept-all
 ```
 
-`--accept-all` accepts the classification rather than blindly including every
-file: effective ADRs and rules are included; obsolete or classifier-excluded
-documents are persisted as excluded.
+`--accept-all` accepts the classifier's recommendation for each governance
+candidate shown in the preview. Effective ADRs, agent rules, and included
+standing rules are persisted as `include`; ineffective ADRs and excluded
+standing rules are persisted as `exclude`. Rows classified as `NotGovernance`
+are omitted.
 
 Use `add` or `edit` to make an exact manual assertion about one file:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -23,7 +23,7 @@ memtrace --help
 | `memtrace doctor [--fix] [--repair-install] [--purge-legacy]` | Diagnose runtime, stale locks, process conflicts, agent skills, and MCP registration. With flags, clean stale runtime state and reinstall local skills/MCP config. |
 | `memtrace mcp` | Run the MCP server for Claude, Cursor, Codex, and other MCP-compatible agents. It attaches to an existing workspace owner or becomes the owner if none is running. |
 | `memtrace index <path>` | Index a repository or workspace into MemDB, then exit. |
-| `memtrace govern <path|glob> [--accept-all]` | Classify governance candidates for review. With `--accept-all`, persist all candidates classified by the current run. |
+| `memtrace govern <path|glob> [--accept-all]` | Classify governance candidates for review. With `--accept-all`, persist the classifier's include/exclude recommendation for every candidate in the current run. |
 | `memtrace govern add|edit <path> ...` | Manually assert or replace one governance document in Cortex decision memory. |
 | `memtrace code-review setup` | Choose the default headless agent for `@memtrace fix this`. |
 | `memtrace code-review --pr <url>` | Review a GitHub pull request using local Memtrace context. |
@@ -76,6 +76,10 @@ memtrace start
 memtrace govern docs/adr
 memtrace govern docs/adr --accept-all
 ```
+
+`--accept-all` accepts the classification rather than blindly including every
+file: effective ADRs and rules are included; obsolete or classifier-excluded
+documents are persisted as excluded.
 
 Use `add` or `edit` to make an exact manual assertion about one file:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -23,6 +23,8 @@ memtrace --help
 | `memtrace doctor [--fix] [--repair-install] [--purge-legacy]` | Diagnose runtime, stale locks, process conflicts, agent skills, and MCP registration. With flags, clean stale runtime state and reinstall local skills/MCP config. |
 | `memtrace mcp` | Run the MCP server for Claude, Cursor, Codex, and other MCP-compatible agents. It attaches to an existing workspace owner or becomes the owner if none is running. |
 | `memtrace index <path>` | Index a repository or workspace into MemDB, then exit. |
+| `memtrace govern <path|glob> [--accept-all]` | Classify governance candidates for review. With `--accept-all`, persist all candidates classified by the current run. |
+| `memtrace govern add|edit <path> ...` | Manually assert or replace one governance document in Cortex decision memory. |
 | `memtrace code-review setup` | Choose the default headless agent for `@memtrace fix this`. |
 | `memtrace code-review --pr <url>` | Review a GitHub pull request using local Memtrace context. |
 | `memtrace pr status` | Show local PR watches registered by `memtrace code-review --post --watch`. |
@@ -57,6 +59,37 @@ same local `.memdb` store, but they have different lifetimes:
 Memtrace keeps an owner lock in the resolved `.memdb` directory, so
 multiple agent sessions should not open duplicate embedded MemDB
 owners for the same workspace.
+
+Cortex uses a separate decision store. `memtrace index`, `--clear`,
+`memtrace reset`, and MCP `index_directory(clear_existing=true)` only
+affect the MemDB code graph; there is no normal Cortex reindex flag.
+See [`cortex.md`](cortex.md).
+
+## Governance intake
+
+The sweep command classifies files for review. It does not persist a
+preview unless you confirm candidates in the Cortex Governance view or
+pass `--accept-all`:
+
+```bash
+memtrace start
+memtrace govern docs/adr
+memtrace govern docs/adr --accept-all
+```
+
+Use `add` or `edit` to make an exact manual assertion about one file:
+
+```bash
+memtrace govern add docs/adr/0007-use-postgres.md \
+  --type adr \
+  --guidance "Use Postgres for durable application state" \
+  --scope 'path:apps/api/**'
+```
+
+Valid `--type` values are `adr`, `agent_rule`, and `standing_rule`.
+`--scope` is optional and accepts comma-separated path selectors. `--ban`
+marks a hard constraint. `edit` replaces the full assertion rather than
+merging omitted fields from the previous one.
 
 ## Doctor and repair
 

--- a/docs/cortex.md
+++ b/docs/cortex.md
@@ -77,6 +77,10 @@ memtrace govern docs/adr
 memtrace govern docs/adr --accept-all
 ```
 
+`--accept-all` persists the classifier's recommendation for each candidate.
+Effective ADRs and rules are included; obsolete or classifier-excluded docs are
+recorded as excluded rather than being forced into governance.
+
 You can also review and confirm candidates in the dashboard's Cortex Governance
 view. Use `govern add` or `govern edit` when you need to assert one exact document
 and its meaning without relying on classification:

--- a/docs/cortex.md
+++ b/docs/cortex.md
@@ -66,20 +66,22 @@ distinctive phrase from a known decision before changing runtime state.
 
 ## Governance intake must be confirmed
 
-Pointing `memtrace govern` at a file, directory, or glob discovers and classifies
-candidates. A preview alone does not add those candidates to decision memory.
+Pointing `memtrace govern` at a file, directory, or glob classifies the matched
+files and shows the governance candidates it recognizes. A preview alone does
+not add those candidates to decision memory.
 
 ```bash
 # Preview and classify candidates for review
 memtrace govern docs/adr
 
-# Persist all candidates classified by this run
+# Persist every governance candidate shown by this run
 memtrace govern docs/adr --accept-all
 ```
 
-`--accept-all` persists the classifier's recommendation for each candidate.
-Effective ADRs and rules are included; obsolete or classifier-excluded docs are
-recorded as excluded rather than being forced into governance.
+`--accept-all` persists the classifier's recommendation for each governance
+candidate shown in the preview. Effective ADRs, agent rules, and included
+standing rules are written as `include`; ineffective ADRs and excluded standing
+rules are written as `exclude`. Rows classified as `NotGovernance` are omitted.
 
 You can also review and confirm candidates in the dashboard's Cortex Governance
 view. Use `govern add` or `govern edit` when you need to assert one exact document

--- a/docs/cortex.md
+++ b/docs/cortex.md
@@ -47,7 +47,7 @@ Then restart or reconnect the MCP client so it reloads the tool list. See
 | Argument | Type | Required | Notes |
 |---|---|---|---|
 | `query` | string | yes | Non-empty description of the decision, ban, or convention. |
-| `top_k` | positive integer | no | Maximum number of results. The server uses a small bounded default when omitted. |
+| `top_k` | positive integer | no | Maximum number of results. Defaults to 10 when omitted. |
 | `min_score` | finite number | no | Drop results below this score. |
 
 Example tool arguments:

--- a/docs/cortex.md
+++ b/docs/cortex.md
@@ -1,0 +1,144 @@
+# Cortex decision memory
+
+Cortex is Memtrace's local memory for decisions, bans, conventions, and
+governing documents. It is separate from the MemDB code graph.
+
+| Store | Contains | Normal refresh path |
+|---|---|---|
+| MemDB code graph | Source symbols, relationships, and git history | `memtrace index`, `memtrace index --clear`, or MCP `index_directory` |
+| Cortex decision memory | Decisions captured from episodes and confirmed governance documents | Automatic capture plus governance review/confirmation |
+
+This distinction matters during recovery. Rebuilding or resetting the code graph
+does not rebuild Cortex.
+
+## Configure one MCP server
+
+The supported public MCP entry point is `memtrace mcp`:
+
+```json
+{
+  "mcpServers": {
+    "memtrace": {
+      "command": "memtrace",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Do not point an MCP client at `memcortex-mcp`, a bundled Node path, a socket, or
+a named pipe. Those are internal implementation details. The normal Memtrace MCP
+server publishes the Cortex tools and proxies their calls over the correct local
+transport on macOS, Linux, and Windows.
+
+Start the workspace runtime before using decision memory:
+
+```bash
+memtrace start
+```
+
+Then restart or reconnect the MCP client so it reloads the tool list. See
+[`mcp-and-transports.md`](mcp-and-transports.md) for client configuration.
+
+## Recall a decision
+
+`recall_decision` accepts a natural-language query and two optional filters:
+
+| Argument | Type | Required | Notes |
+|---|---|---|---|
+| `query` | string | yes | Non-empty description of the decision, ban, or convention. |
+| `top_k` | positive integer | no | Maximum number of results. The server uses a small bounded default when omitted. |
+| `min_score` | finite number | no | Drop results below this score. |
+
+Example tool arguments:
+
+```json
+{
+  "query": "why do we avoid raw SQL in request handlers?",
+  "top_k": 5,
+  "min_score": 0.05
+}
+```
+
+An honest `CannotProve` response means Cortex did not find enough evidence for
+that query. It is not proof that the runtime or store is broken. Try a short,
+distinctive phrase from a known decision before changing runtime state.
+
+## Governance intake must be confirmed
+
+Pointing `memtrace govern` at a file, directory, or glob discovers and classifies
+candidates. A preview alone does not add those candidates to decision memory.
+
+```bash
+# Preview and classify candidates for review
+memtrace govern docs/adr
+
+# Persist all candidates classified by this run
+memtrace govern docs/adr --accept-all
+```
+
+You can also review and confirm candidates in the dashboard's Cortex Governance
+view. Use `govern add` or `govern edit` when you need to assert one exact document
+and its meaning without relying on classification:
+
+```bash
+memtrace govern add docs/adr/0007-use-postgres.md \
+  --type adr \
+  --guidance "Use Postgres for durable application state" \
+  --scope 'path:apps/api/**'
+
+memtrace govern edit docs/adr/0007-use-postgres.md \
+  --type adr \
+  --guidance "Use Postgres for durable application state" \
+  --scope 'path:apps/**'
+```
+
+`edit` replaces the full assertion. Omitting `--scope` or `--ban` clears that
+part of the previous assertion.
+
+## Status and recovery
+
+Run `memtrace start`, then inspect Cortex directly rather than inferring its
+health from code-index counts:
+
+```bash
+curl -s http://localhost:3030/api/cortex/status
+memtrace status --json
+```
+
+On Windows PowerShell:
+
+```powershell
+Invoke-RestMethod http://localhost:3030/api/cortex/status
+memtrace status --json
+```
+
+The same status is visible in the Cortex tab at `http://localhost:3030`.
+Wait for `snapshotState` to become `fresh` before treating decision counts as
+current. A temporarily false `daemonAvailable` can mean the serial endpoint is
+busy, so retry before assuming the daemon is dead.
+
+If the endpoint stays unavailable:
+
+```bash
+memtrace stop
+memtrace doctor
+memtrace doctor --fix
+memtrace start
+```
+
+Restart the MCP client after the runtime is healthy, then call
+`recall_decision` through the existing `memtrace` MCP server.
+
+There is no supported Cortex reindex CLI command or MCP flag. These operations
+only rebuild or clear the MemDB code graph:
+
+- `memtrace index`
+- `memtrace index --clear`
+- `index_directory` with `clear_existing: true`
+- `memtrace reset`
+
+Do not delete `~/.memtrace/cortex-store` as a recovery step. If the restart and
+governance confirmation flow still fail, capture the Cortex status JSON,
+`memtrace status --json`, `memtrace --version`, the OS, and the exact
+`recall_decision` arguments for a bug report.

--- a/docs/mcp-and-transports.md
+++ b/docs/mcp-and-transports.md
@@ -130,6 +130,23 @@ its stdio". Per-tool config locations:
 The Memtrace installer handles this for you — most users never edit
 these files.
 
+### Cortex uses the same MCP entry
+
+Cortex decision-memory tools are exposed by the normal `memtrace mcp`
+server. Configure the `memtrace` entry above once. Do not add a second
+entry for `memcortex-mcp`, manually link a bundled Node path, or set a
+socket/named-pipe flag. The internal Cortex sidecars and OS transport are
+managed by Memtrace.
+
+Run `memtrace start` before using Cortex so its decision-capture service
+and local endpoint are available. If the MCP client was already open,
+restart or reconnect it after starting Memtrace. The five Cortex tools,
+including `recall_decision`, should then appear in the ordinary Memtrace
+tool list.
+
+For status checks, governance confirmation, and the difference between
+code reindexing and decision memory, see [`cortex.md`](cortex.md).
+
 ## Streamable-HTTP transport
 
 ### How it looks

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -262,6 +262,58 @@ bad replay or to apply a different time window.
 Delete episodes + their historical snapshots. Run before
 `replay_history` if you want to redo replay from scratch.
 
+## Cortex decision memory
+
+These tools are published by the normal `memtrace mcp` server. Never
+configure an MCP client to launch `memcortex-mcp` directly. Start the
+workspace with `memtrace start` so the local Cortex endpoint is available.
+
+### `recall_decision`
+
+Free-text recall over decisions, bans, and conventions. Returns ranked
+evidence or an honest `CannotProve` result.
+
+| Arg | Type | Required | Notes |
+|---|---|---|---|
+| `query` | string | yes | Must not be empty. Use a phrase that describes the decision rather than a symbol id. |
+| `top_k` | positive integer | no | Result cap. The server applies a small bounded default when omitted. Zero is invalid. |
+| `min_score` | finite number | no | Exclude results below this score. |
+
+Example:
+
+```json
+{
+  "query": "why do we avoid raw SQL in request handlers?",
+  "top_k": 5,
+  "min_score": 0.05
+}
+```
+
+### `verify_intent`
+
+Check whether a recalled decision held across its implementation arc.
+Pass the positive `decision_id` returned by `recall_decision`, not a
+symbol name.
+
+### `get_arc`
+
+Return the episodes connected to a recalled decision. Takes the positive
+`decision_id` returned by `recall_decision`.
+
+### `why_is_this_here`
+
+Return decision/conversation provenance governing a symbol. Takes a
+positive Cortex `symbol_id`.
+
+### `governing_contracts`
+
+Return contracts that constrain a symbol, or `CannotProve` when Cortex
+has no such evidence. Takes a positive Cortex `symbol_id`.
+
+`index_directory`, `clear_existing`, and the source-code reset commands
+do not rebuild these tools' decision store. See [`cortex.md`](cortex.md)
+for the governance and recovery flow.
+
 ## Processes + flows
 
 ### `list_processes`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -276,7 +276,7 @@ evidence or an honest `CannotProve` result.
 | Arg | Type | Required | Notes |
 |---|---|---|---|
 | `query` | string | yes | Must not be empty. Use a phrase that describes the decision rather than a symbol id. |
-| `top_k` | positive integer | no | Result cap. The server applies a small bounded default when omitted. Zero is invalid. |
+| `top_k` | positive integer | no | Result cap. Defaults to 10 when omitted. Zero is invalid. |
 | `min_score` | finite number | no | Exclude results below this score. |
 
 Example:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,6 +11,7 @@ find your symptom, follow the fix.
 - [Claude Code hook JSON validation failed](#claude-code-hook-json-validation-failed)
 - [Agent says "Memtrace index is empty"](#agent-says-memtrace-index-is-empty-0-nodes-0-edges-at-session-start)
 - [Agent isn't using the MCP](#agent-isnt-using-the-mcp)
+- [Cortex recall is missing, unavailable, or empty](#cortex-recall-is-missing-unavailable-or-empty)
 - [Dashboard graph or timeline looks partial after cold start](#dashboard-graph-or-timeline-looks-partial-after-cold-start)
 - [`MEMTRACE_TRANSPORT=sse` hangs](#memtrace_transportsse-hangs)
 - [Indexing hangs / never finishes](#indexing-hangs--never-finishes)
@@ -316,6 +317,57 @@ If those directories are empty, repair the local skills/MCP install:
 ```bash
 memtrace doctor --fix --repair-install
 ```
+
+## Cortex recall is missing, unavailable, or empty
+
+First, check the MCP configuration. Cortex tools come through the normal
+Memtrace server:
+
+```json
+{
+  "mcpServers": {
+    "memtrace": {
+      "command": "memtrace",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Do not configure `memcortex-mcp`, a package-internal Node path, a Unix
+socket, or a Windows named pipe. Remove any second Cortex MCP entry.
+
+Then check the runtime and Cortex's own status:
+
+```bash
+memtrace start
+curl -s http://localhost:3030/api/cortex/status
+```
+
+Windows PowerShell:
+
+```powershell
+memtrace start
+Invoke-RestMethod http://localhost:3030/api/cortex/status
+```
+
+Wait until `snapshotState` is `fresh`. Restart or reconnect the MCP client
+after Memtrace starts so it reloads the tool list.
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Cortex tools are absent | Wrong/stale MCP registration | Keep only `command: "memtrace"`, `args: ["mcp"]`; run `memtrace doctor --fix --repair-install`; restart the client. |
+| Tool reports Cortex unavailable or the local transport closed | Runtime or sidecar is not ready | Run `memtrace stop`, `memtrace doctor --fix`, then `memtrace start`; poll `/api/cortex/status`. |
+| Status is healthy but recall returns `CannotProve` | No evidence matched the query | Try a short distinctive phrase from a known decision. Check that governance candidates were confirmed. |
+| `memtrace govern` lists files but the Cortex index/count does not change | A sweep is classification/review, not persistence | Confirm in the dashboard, use `--accept-all`, or use `govern add/edit` for one exact assertion. |
+| `memtrace index --clear` or `memtrace reset` did not change Cortex | Expected: those commands only affect the MemDB code graph | Use the Cortex runtime and governance flow; do not repeat source reindexing. |
+
+There is no supported full Cortex reindex command or MCP flag. Do not
+delete `~/.memtrace/cortex-store`. If recovery still fails, save the
+output of `/api/cortex/status`, `memtrace status --json`,
+`memtrace --version`, your OS, and the exact `recall_decision` request.
+
+See [`cortex.md`](cortex.md) for parameter details and governance examples.
 
 ## Dashboard graph or timeline looks partial after cold start
 


### PR DESCRIPTION
Documents the supported memtrace mcp entry point, decision recall parameters, governance confirmation, Cortex-specific status checks, and safe recovery. It also makes explicit that code reindex/reset operations do not rebuild Cortex and that users should not wire internal sidecars or delete the decision store.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/syncable-dev/codesmith/memtrace-public/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786593749&installation_id=130072409&pr_number=50&repository=syncable-dev%2Fmemtrace-public&return_to=https%3A%2F%2Fgithub.com%2Fsyncable-dev%2Fmemtrace-public%2Fpull%2F50&signature=47b138e2da613463abd7bf65e2fd0b4061bcfbbedda016e4db230f8078417e1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->