### PR TITLE
docs: fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ Detailed breakdowns: [BENCHMARKS-v0.3.22.md](BENCHMARKS-v0.3.22.md) · [BENCHMAR
 
 ## GitHub Star Growth
 
-<a href="https://www.star-history.com/syncable-dev/memtrace-public">
+<a href="https://star-history.dera.page/#syncable-dev/memtrace-public&type=date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=syncable-dev/memtrace-public&type=date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=syncable-dev/memtrace-public&type=date&legend=top-left" />
-    <img alt="Memtrace GitHub star growth over time" src="https://api.star-history.com/chart?repos=syncable-dev/memtrace-public&type=date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=syncable-dev/memtrace-public&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=syncable-dev/memtrace-public&type=date&legend=top-left" />
+    <img alt="Memtrace GitHub star growth over time" src="https://star-history.dera.page/svg?repos=syncable-dev/memtrace-public&type=date&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
The current star history chart no longer renders because of GitHub stargazer API restrictions. This change switches the chart over to a working alternative that needs no API token, restoring the star growth graph in the README.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/syncable-dev/codesmith/memtrace-public/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789737959&installation_model_id=20810&pr_number=74&repository=syncable-dev%2Fmemtrace-public&return_to=https%3A%2F%2Fgithub.com%2Fsyncable-dev%2Fmemtrace-public%2Fpull%2F74&signature=0c6031c9a57cc2e9ef298f259177352594e990c01fa4c1ce1c6a75163502255c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->